### PR TITLE
Fix backported repurposed structure compat

### DIFF
--- a/Common/src/main/resources/data/repurposed_structures/pool_additions/villages/badlands/houses.json
+++ b/Common/src/main/resources/data/repurposed_structures/pool_additions/villages/badlands/houses.json
@@ -1,5 +1,5 @@
 {
-  "target_pool": "repurposed_structures:villages/badlands/houses",
+  "name": "repurposed_structures:villages/badlands/houses",
   "fallback": "minecraft:empty",
   "elements": [
     {

--- a/Common/src/main/resources/data/repurposed_structures/pool_additions/villages/bamboo/houses.json
+++ b/Common/src/main/resources/data/repurposed_structures/pool_additions/villages/bamboo/houses.json
@@ -1,5 +1,5 @@
 {
-  "target_pool": "repurposed_structures:villages/bamboo/houses",
+  "name": "repurposed_structures:villages/bamboo/houses",
   "fallback": "minecraft:empty",
   "elements": [
     {

--- a/Common/src/main/resources/data/repurposed_structures/pool_additions/villages/birch/houses.json
+++ b/Common/src/main/resources/data/repurposed_structures/pool_additions/villages/birch/houses.json
@@ -1,5 +1,5 @@
 {
-  "target_pool": "repurposed_structures:villages/birch/houses",
+  "name": "repurposed_structures:villages/birch/houses",
   "fallback": "minecraft:empty",
   "elements": [
     {

--- a/Common/src/main/resources/data/repurposed_structures/pool_additions/villages/cherry/houses.json
+++ b/Common/src/main/resources/data/repurposed_structures/pool_additions/villages/cherry/houses.json
@@ -1,5 +1,5 @@
 {
-  "target_pool": "repurposed_structures:villages/cherry/houses",
+  "name": "repurposed_structures:villages/cherry/houses",
   "fallback": "minecraft:empty",
   "elements": [
     {

--- a/Common/src/main/resources/data/repurposed_structures/pool_additions/villages/dark_forest/houses.json
+++ b/Common/src/main/resources/data/repurposed_structures/pool_additions/villages/dark_forest/houses.json
@@ -1,5 +1,5 @@
 {
-  "target_pool": "repurposed_structures:villages/dark_forest/houses",
+  "name": "repurposed_structures:villages/dark_forest/houses",
   "fallback": "minecraft:empty",
   "elements": [
     {

--- a/Common/src/main/resources/data/repurposed_structures/pool_additions/villages/giant_taiga/houses.json
+++ b/Common/src/main/resources/data/repurposed_structures/pool_additions/villages/giant_taiga/houses.json
@@ -1,5 +1,5 @@
 {
-  "target_pool": "repurposed_structures:villages/giant_taiga/houses",
+  "name": "repurposed_structures:villages/giant_taiga/houses",
   "fallback": "minecraft:empty",
   "elements": [
     {

--- a/Common/src/main/resources/data/repurposed_structures/pool_additions/villages/jungle/houses.json
+++ b/Common/src/main/resources/data/repurposed_structures/pool_additions/villages/jungle/houses.json
@@ -1,5 +1,5 @@
 {
-  "target_pool": "repurposed_structures:villages/jungle/houses",
+  "name": "repurposed_structures:villages/jungle/houses",
   "fallback": "minecraft:empty",
   "elements": [
     {

--- a/Common/src/main/resources/data/repurposed_structures/pool_additions/villages/mountains/houses.json
+++ b/Common/src/main/resources/data/repurposed_structures/pool_additions/villages/mountains/houses.json
@@ -1,5 +1,5 @@
 {
-  "target_pool": "repurposed_structures:villages/mountains/houses",
+  "name": "repurposed_structures:villages/mountains/houses",
   "fallback": "minecraft:empty",
   "elements": [
     {

--- a/Common/src/main/resources/data/repurposed_structures/pool_additions/villages/mushroom/houses.json
+++ b/Common/src/main/resources/data/repurposed_structures/pool_additions/villages/mushroom/houses.json
@@ -1,5 +1,5 @@
 {
-  "target_pool": "repurposed_structures:villages/mushroom/houses",
+  "name": "repurposed_structures:villages/mushroom/houses",
   "fallback": "minecraft:empty",
   "elements": [
     {

--- a/Common/src/main/resources/data/repurposed_structures/pool_additions/villages/oak/houses.json
+++ b/Common/src/main/resources/data/repurposed_structures/pool_additions/villages/oak/houses.json
@@ -1,5 +1,5 @@
 {
-  "target_pool": "repurposed_structures:villages/oak/houses",
+  "name": "repurposed_structures:villages/oak/houses",
   "fallback": "minecraft:empty",
   "elements": [
     {

--- a/Common/src/main/resources/data/repurposed_structures/pool_additions/villages/ocean/houses.json
+++ b/Common/src/main/resources/data/repurposed_structures/pool_additions/villages/ocean/houses.json
@@ -1,5 +1,5 @@
 {
-  "target_pool": "repurposed_structures:villages/ocean/houses",
+  "name": "repurposed_structures:villages/ocean/houses",
   "fallback": "minecraft:empty",
   "elements": [
     {

--- a/Common/src/main/resources/data/repurposed_structures/pool_additions/villages/swamp/houses.json
+++ b/Common/src/main/resources/data/repurposed_structures/pool_additions/villages/swamp/houses.json
@@ -1,5 +1,5 @@
 {
-  "target_pool": "repurposed_structures:villages/swamp/houses",
+  "name": "repurposed_structures:villages/swamp/houses",
   "fallback": "minecraft:empty",
   "elements": [
     {

--- a/Common/src/main/resources/data/repurposed_structures/rs_pieces_spawn_counts_additions/village_badlands.json
+++ b/Common/src/main/resources/data/repurposed_structures/rs_pieces_spawn_counts_additions/village_badlands.json
@@ -1,5 +1,4 @@
 {
-  "target_structure": "repurposed_structures:village_badlands",
   "pieces_spawn_counts": [
     {
       "nbt_piece_name": "biomeswevegone:repurposed_structures/villages/badlands/forager",

--- a/Common/src/main/resources/data/repurposed_structures/rs_pieces_spawn_counts_additions/village_bamboo.json
+++ b/Common/src/main/resources/data/repurposed_structures/rs_pieces_spawn_counts_additions/village_bamboo.json
@@ -1,5 +1,4 @@
 {
-  "target_structure": "repurposed_structures:village_bamboo",
   "pieces_spawn_counts": [
     {
       "nbt_piece_name": "biomeswevegone:repurposed_structures/villages/bamboo/forager",

--- a/Common/src/main/resources/data/repurposed_structures/rs_pieces_spawn_counts_additions/village_birch.json
+++ b/Common/src/main/resources/data/repurposed_structures/rs_pieces_spawn_counts_additions/village_birch.json
@@ -1,5 +1,4 @@
 {
-  "target_structure": "repurposed_structures:village_birch",
   "pieces_spawn_counts": [
     {
       "nbt_piece_name": "biomeswevegone:repurposed_structures/villages/birch/forager",

--- a/Common/src/main/resources/data/repurposed_structures/rs_pieces_spawn_counts_additions/village_cherry.json
+++ b/Common/src/main/resources/data/repurposed_structures/rs_pieces_spawn_counts_additions/village_cherry.json
@@ -1,5 +1,4 @@
 {
-  "target_structure": "repurposed_structures:village_cherry",
   "pieces_spawn_counts": [
     {
       "nbt_piece_name": "biomeswevegone:repurposed_structures/villages/cherry/forager",

--- a/Common/src/main/resources/data/repurposed_structures/rs_pieces_spawn_counts_additions/village_dark_forest.json
+++ b/Common/src/main/resources/data/repurposed_structures/rs_pieces_spawn_counts_additions/village_dark_forest.json
@@ -1,5 +1,4 @@
 {
-  "target_structure": "repurposed_structures:village_dark_forest",
   "pieces_spawn_counts": [
     {
       "nbt_piece_name": "biomeswevegone:repurposed_structures/villages/dark_forest/forager",

--- a/Common/src/main/resources/data/repurposed_structures/rs_pieces_spawn_counts_additions/village_giant_taiga.json
+++ b/Common/src/main/resources/data/repurposed_structures/rs_pieces_spawn_counts_additions/village_giant_taiga.json
@@ -1,5 +1,4 @@
 {
-  "target_structure": "repurposed_structures:village_giant_taiga",
   "pieces_spawn_counts": [
     {
       "nbt_piece_name": "biomeswevegone:repurposed_structures/villages/giant_taiga/forager",

--- a/Common/src/main/resources/data/repurposed_structures/rs_pieces_spawn_counts_additions/village_jungle.json
+++ b/Common/src/main/resources/data/repurposed_structures/rs_pieces_spawn_counts_additions/village_jungle.json
@@ -1,5 +1,4 @@
 {
-  "target_structure": "repurposed_structures:village_jungle",
   "pieces_spawn_counts": [
     {
       "nbt_piece_name": "biomeswevegone:repurposed_structures/villages/jungle/forager",

--- a/Common/src/main/resources/data/repurposed_structures/rs_pieces_spawn_counts_additions/village_mountains.json
+++ b/Common/src/main/resources/data/repurposed_structures/rs_pieces_spawn_counts_additions/village_mountains.json
@@ -1,5 +1,4 @@
 {
-  "target_structure": "repurposed_structures:village_mountains",
   "pieces_spawn_counts": [
     {
       "nbt_piece_name": "biomeswevegone:repurposed_structures/villages/mountains/forager",

--- a/Common/src/main/resources/data/repurposed_structures/rs_pieces_spawn_counts_additions/village_mushroom.json
+++ b/Common/src/main/resources/data/repurposed_structures/rs_pieces_spawn_counts_additions/village_mushroom.json
@@ -1,5 +1,4 @@
 {
-  "target_structure": "repurposed_structures:village_mushroom",
   "pieces_spawn_counts": [
     {
       "nbt_piece_name": "biomeswevegone:repurposed_structures/villages/mushroom/forager",

--- a/Common/src/main/resources/data/repurposed_structures/rs_pieces_spawn_counts_additions/village_oak.json
+++ b/Common/src/main/resources/data/repurposed_structures/rs_pieces_spawn_counts_additions/village_oak.json
@@ -1,5 +1,4 @@
 {
-  "target_structure": "repurposed_structures:village_oak",
   "pieces_spawn_counts": [
     {
       "nbt_piece_name": "biomeswevegone:repurposed_structures/villages/oak/forager",

--- a/Common/src/main/resources/data/repurposed_structures/rs_pieces_spawn_counts_additions/village_ocean.json
+++ b/Common/src/main/resources/data/repurposed_structures/rs_pieces_spawn_counts_additions/village_ocean.json
@@ -1,5 +1,4 @@
 {
-  "target_structure": "repurposed_structures:village_ocean",
   "pieces_spawn_counts": [
     {
       "nbt_piece_name": "biomeswevegone:repurposed_structures/villages/ocean/forager",

--- a/Common/src/main/resources/data/repurposed_structures/rs_pieces_spawn_counts_additions/village_swamp.json
+++ b/Common/src/main/resources/data/repurposed_structures/rs_pieces_spawn_counts_additions/village_swamp.json
@@ -1,5 +1,4 @@
 {
-  "target_structure": "repurposed_structures:village_swamp",
   "pieces_spawn_counts": [
     {
       "nbt_piece_name": "biomeswevegone:repurposed_structures/villages/swamp/forager",


### PR DESCRIPTION
closes https://github.com/TelepathicGrunt/RepurposedStructures/issues/371

The issue is the backport did not account for older formats to the files themselves. I built this mod locally and tested in production to verify the logspam stops and the houses are showing up in-world properly